### PR TITLE
allow multi-line-comment extraction

### DIFF
--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -36,7 +36,7 @@ var TypeScript, _, traverse; // from global scope
     //var validationKeywords = ["type", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum", "multipleOf",
     //    "minLength", "maxLength", "format", "pattern", "minItems", "maxItems", "uniqueItems", "default",
     //    "additionalProperties", "title"];
-    var annotedValidationKeywordPattern = /@[a-z.]+\s*[^\n]+/gi;
+    var annotedValidationKeywordPattern=/@[a-z\.]+\s+[\s\S]*?((?=\n@)|(?=$))/gi;
     var TypescriptASTFlags = {"optionalName": 4, "arrayType": 8};
     var defaultProperties = {additionalProperties: false};
 
@@ -391,6 +391,7 @@ var TypeScript, _, traverse; // from global scope
     }
 
     function escape(str) {
+        return str;
         return str
             .replace(/[\\]/g, '\\\\')
             .replace(/[\"]/g, '\\\"')

--- a/lib/typson.js
+++ b/lib/typson.js
@@ -109,6 +109,7 @@ var _; // from global scope
     }
 
     function escapeContent(str) {
+        return str;
         return str
             .replace(/[\\]/g, '\\\\')
             .replace(/[\"]/g, '\\\"')


### PR DESCRIPTION
In block comments, multiple line could be spread to match the keyword-value pair as https://regex101.com/r/mN2cT8/1

This could make the escape unnecessary. JSON.stringify will handle the quotes and \ automatically.

One limitation, after the `@keyword multi line comment` started, no regular comments are allowed.  